### PR TITLE
fix: format duration for period param

### DIFF
--- a/newsapi/newsapi.go
+++ b/newsapi/newsapi.go
@@ -105,7 +105,7 @@ func (n *newsApi) ComposeURL(path string, query string) url.URL {
 	if query != "" {
 		q.Set("q", query)
 		if n.period != nil {
-			q.Set("q", q.Get("q")+"+when:"+n.period.String())
+			q.Set("q", q.Get("q")+"+when:"+FormatDuration(*n.period))
 		}
 		if n.endDate != nil {
 			q.Set("q", q.Get("q")+"+before:"+n.endDate.Format("2006-01-02"))

--- a/newsapi/utils.go
+++ b/newsapi/utils.go
@@ -274,6 +274,32 @@ func GetOriginalLink(sourceLink string) (string, error) {
 	return originalLink, nil
 }
 
+func FormatDuration(duration time.Duration) string {
+	days := duration / (24 * time.Hour)
+	duration -= days * 24 * time.Hour
+
+	hours := duration / time.Hour
+	duration -= hours * time.Hour
+
+	minutes := duration / time.Minute
+
+	var formatted string
+
+	if days > 0 {
+		formatted += fmt.Sprintf("%dd ", days)
+	}
+
+	if hours > 0 {
+		formatted += fmt.Sprintf("%dh ", hours)
+	}
+
+	if minutes > 0 || formatted == "" {
+		formatted += fmt.Sprintf("%dm", minutes)
+	}
+
+	return formatted
+}
+
 var (
 	newsHostToSelector = map[string]string{
 		"tw.news.yahoo.com":  ".caas-body",


### PR DESCRIPTION
Because the duration format in golang is not the same as the duration format in google news which will not get any results.
So I did a format adjustment in the param period.